### PR TITLE
optimize random num generation for tests and test program

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,10 +73,11 @@ int main(int argc, char *argv[]) {
   // the correct element.
   auto db_copy(make_unique<uint8_t[]>(number_of_items * size_per_item));
 
-  random_device rd;
+  seal::Blake2xbPRNGFactory factory;
+  auto gen =  factory.create();
   for (uint64_t i = 0; i < number_of_items; i++) {
     for (uint64_t j = 0; j < size_per_item; j++) {
-      uint8_t val = rd() % 256;
+      uint8_t val = gen->generate() % 256;
       db.get()[(i * size_per_item) + j] = val;
       db_copy.get()[(i * size_per_item) + j] = val;
     }
@@ -92,6 +93,7 @@ int main(int argc, char *argv[]) {
   cout << "Main: database pre processed " << endl;
 
   // Choose an index of an element in the DB
+  random_device rd;
   uint64_t ele_index =
       rd() % number_of_items; // element in DB at random position
   uint64_t index = client.get_fv_index(ele_index);   // index of FV plaintext

--- a/src/pir_server.cpp
+++ b/src/pir_server.cpp
@@ -121,7 +121,7 @@ void PIRServer::set_database(const std::unique_ptr<const uint8_t[]> &bytes,
   cout << "adding: " << matrix_plaintexts - current_plaintexts
        << " FV plaintexts of padding (equivalent to: "
        << (matrix_plaintexts - current_plaintexts) *
-              elements_per_ptxt(logtp, N, ele_size)
+              elements_per_ptxt(logt, N, ele_size)
        << " elements)" << endl;
 #endif
 

--- a/test/query_test.cpp
+++ b/test/query_test.cpp
@@ -70,10 +70,12 @@ int query_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
   // the correct element.
   auto db_copy(make_unique<uint8_t[]>(number_of_items * size_per_item));
 
-  random_device rd;
+  seal::Blake2xbPRNGFactory factory;
+  auto gen = factory.create();
+
   for (uint64_t i = 0; i < number_of_items; i++) {
     for (uint64_t j = 0; j < size_per_item; j++) {
-      uint8_t val = rd() % 256;
+      uint8_t val = gen->generate() % 256;
       db.get()[(i * size_per_item) + j] = val;
       db_copy.get()[(i * size_per_item) + j] = val;
     }
@@ -100,6 +102,7 @@ int query_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
   auto time_pre_us =
       duration_cast<microseconds>(time_pre_e - time_pre_s).count();
 
+  random_device rd;
   // Choose an index of an element in the DB
   uint64_t ele_index =
       rd() % number_of_items; // element in DB at random position

--- a/test/replace_test.cpp
+++ b/test/replace_test.cpp
@@ -64,10 +64,12 @@ int replace_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
   // the correct element.
   auto db_copy(make_unique<uint8_t[]>(number_of_items * size_per_item));
 
-  random_device rd;
+  seal::Blake2xbPRNGFactory factory;
+  auto gen =  factory.create();
+
   for (uint64_t i = 0; i < number_of_items; i++) {
     for (uint64_t j = 0; j < size_per_item; j++) {
-      uint8_t val = rd() % 256;
+      uint8_t val = gen->generate() % 256;
       db.get()[(i * size_per_item) + j] = val;
       db_copy.get()[(i * size_per_item) + j] = val;
     }
@@ -96,7 +98,9 @@ int replace_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
   auto time_pre_us =
       duration_cast<microseconds>(time_pre_e - time_pre_s).count();
 
+
   // Choose an index of an element in the DB
+  random_device rd;
   uint64_t ele_index =
       rd() % number_of_items; // element in DB at random position
   uint64_t index = client.get_fv_index(ele_index);   // index of FV plaintext

--- a/test/simple_query_test.cpp
+++ b/test/simple_query_test.cpp
@@ -64,10 +64,12 @@ int simple_query_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
   // the correct element.
   auto db_copy(make_unique<uint8_t[]>(number_of_items * size_per_item));
 
-  random_device rd;
+  seal::Blake2xbPRNGFactory factory;
+  auto gen =  factory.create();
+
   for (uint64_t i = 0; i < number_of_items; i++) {
     for (uint64_t j = 0; j < size_per_item; j++) {
-      uint8_t val = rd() % 256;
+      uint8_t val = gen->generate() % 256;
       db.get()[(i * size_per_item) + j] = val;
       db_copy.get()[(i * size_per_item) + j] = val;
     }
@@ -92,6 +94,7 @@ int simple_query_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
       duration_cast<microseconds>(time_pre_e - time_pre_s).count();
 
   // Choose an index of an element in the DB
+  random_device rd;
   uint64_t ele_index =
       rd() % number_of_items; // element in DB at random position
   uint64_t index = client.get_fv_index(ele_index);   // index of FV plaintext


### PR DESCRIPTION
This incorporates #15 , and also addresses #22 and #18.

It basically just uses a PRG instead of random_device to generate randomness for our tests (including test database that we use in main program) and also fixes a typo.